### PR TITLE
Add possible values for K & V quantization

### DIFF
--- a/bindings/binding.cpp
+++ b/bindings/binding.cpp
@@ -943,7 +943,7 @@ const char* InferToReadbackBuffer(
                 finishReason = "StopString";
                 break;
             } else if (matchInfo.result == MatchTrie::MatchResult::MATCHED_REWIND) {
-                llama_kv_cache_seq_rm(context, 0, rewindState.position + 1, -1);
+                llama_kv_cache_seq_rm(context, 0, rewindPos + 1, -1);
 
                 // Reset the detokenizer too when rewinding
                 if (readbackBufferPtr->detokenizer) {

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -59,7 +59,9 @@ model:
   enable_yarn: false
 
   # K cache quantization type (default: F16)
+  # Possible values: 'FP32', 'FP16', 'Q8_0', 'Q5_1','Q5_0', 'Q4_1', 'Q4_0'.
   cache_mode_k: F16
 
   # V cache quantization type (default: F16)
+  # Possible values: 'FP32', 'FP16', 'Q8_0', 'Q5_1','Q5_0', 'Q4_1', 'Q4_0'.
   cache_mode_v: F16


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
No problem

**Why should this feature be added?**
This just adds possible values for kv quantization in the config sample to match that of tabbyapi's

**Examples**
Come from llama.cpp -> you expect lower case options eg. q8_0 not Q8_0
Come from tabbyapi -> you try to use Q8 not Q8_0 (i did this)

**Additional context**
I didn't add Q8_1 because it loads partially then causes a core dump.

```
llama_init_from_model: KV self size  = 1008.00 MiB, K (q8_1):  504.00 MiB, V (q8_1):  504.00 MiB
llama_init_from_model:  CUDA_Host  output buffer size =     0.58 MiB
/__w/YALS/YALS/bindings/build/_deps/llama-src/ggml/src/ggml-backend.cpp:748: pre-allocated tensor (k_cache_view-0 (copy of Kcur-0)) in a buffer (CUDA0) that cannot run the operation (CPY)
Could not attach to process.  If your uid matches the uid of the target
process, check the setting of /proc/sys/kernel/yama/ptrace_scope, or try
again as the root user.  For more details, see /etc/sysctl.d/10-ptrace.conf
ptrace: Operation not permitted.
No stack.
```