### PR TITLE
Adding Vulkan and HIP (ROCM) support

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -45,6 +45,9 @@ Optionally, environment variables can be set for certain architectures when buil
 - `MAX_JOBS`: Number of parallel jobs (defaults to the number of CPU cores)
 - `GGML_CUDA=1`: Enables CUDA support
 - `CMAKE_CUDA_ARCHITECTURES`: Specifies CUDA compute capabilities (defaults to `native` if using CMake > 3.24)
+- `DGGML_VULKAN=1`: Enables Vulkan Support
+- `DGGML_HIP=1`: Enables HIP ROCM Support (Requires specifying DAMDGPU_TARGETS
+- `DAMDGPU_TARGETS`: Specify ROCM target (example: `gfx1030`)
 
 ## Running
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -46,7 +46,7 @@ Optionally, environment variables can be set for certain architectures when buil
 - `GGML_CUDA=1`: Enables CUDA support
 - `CMAKE_CUDA_ARCHITECTURES`: Specifies CUDA compute capabilities (defaults to `native` if using CMake > 3.24)
 - `DGGML_VULKAN=1`: Enables Vulkan Support
-- `DGGML_HIP=1`: Enables HIP ROCM Support (Requires specifying DAMDGPU_TARGETS
+- `DGGML_HIP=1`: Enables HIP ROCM Support (Requires specifying DAMDGPU_TARGETS)
 - `DAMDGPU_TARGETS`: Specify ROCM target (example: `gfx1030`)
 
 ## Running

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -45,9 +45,9 @@ Optionally, environment variables can be set for certain architectures when buil
 - `MAX_JOBS`: Number of parallel jobs (defaults to the number of CPU cores)
 - `GGML_CUDA=1`: Enables CUDA support
 - `CMAKE_CUDA_ARCHITECTURES`: Specifies CUDA compute capabilities (defaults to `native` if using CMake > 3.24)
-- `DGGML_VULKAN=1`: Enables Vulkan Support
-- `DGGML_HIP=1`: Enables HIP ROCM Support (Requires specifying DAMDGPU_TARGETS, Linux only)
-- `DAMDGPU_TARGETS`: Specify ROCM target (example: `gfx1030`)
+- `GGML_VULKAN=1`: Enables Vulkan Support
+- `GGML_HIP=1`: Enables HIP ROCM Support (Requires specifying DAMDGPU_TARGETS, Linux only)
+- `AMDGPU_TARGETS`: Specify ROCM target (example: `gfx1030`)
 
 ## Running
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -46,7 +46,7 @@ Optionally, environment variables can be set for certain architectures when buil
 - `GGML_CUDA=1`: Enables CUDA support
 - `CMAKE_CUDA_ARCHITECTURES`: Specifies CUDA compute capabilities (defaults to `native` if using CMake > 3.24)
 - `DGGML_VULKAN=1`: Enables Vulkan Support
-- `DGGML_HIP=1`: Enables HIP ROCM Support (Requires specifying DAMDGPU_TARGETS)
+- `DGGML_HIP=1`: Enables HIP ROCM Support (Requires specifying DAMDGPU_TARGETS, Linux only)
 - `DAMDGPU_TARGETS`: Specify ROCM target (example: `gfx1030`)
 
 ## Running

--- a/bindings/bindings.ps1
+++ b/bindings/bindings.ps1
@@ -26,10 +26,10 @@ if ($env:GGML_CUDA -eq 1) {
     }
 }
 
-if ($env:DGGML_VULKAN -eq 1) {
+if ($env:GGML_VULKAN -eq 1) {
     Write-Host "Vulkan enabled, including in build"
 
-    $extraCmakeArgs += "-DGGML_VULKAN=ON"
+    $extraCmakeArgs += "-GGML_VULKAN=ON"
 }
 
 cmake . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release $extraCmakeArgs

--- a/bindings/bindings.ps1
+++ b/bindings/bindings.ps1
@@ -32,6 +32,18 @@ if ($env:DGGML_VULKAN -eq 1) {
     $extraCmakeArgs += "-DGGML_VULKAN=ON"
 }
 
+if ($env:DGGML_HIP -eq 1) {
+    Write-Host "HIP enabled, including in build"
+
+    $extraCmakeArgs += "-DGGML_HIP=ON"
+
+    if ($env:DAMDGPU_TARGETS) {
+        $extraCmakeArgs += @(
+            "-DDAMDGPU_TARGETS=$env:DAMDGPU_TARGETS"
+        )
+    }
+}
+
 cmake . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release $extraCmakeArgs
 cmake --build build --config Release --target deno_cpp_binding -j $jobs
 Copy-Item build/*.dll ../lib

--- a/bindings/bindings.ps1
+++ b/bindings/bindings.ps1
@@ -32,18 +32,6 @@ if ($env:DGGML_VULKAN -eq 1) {
     $extraCmakeArgs += "-DGGML_VULKAN=ON"
 }
 
-if ($env:DGGML_HIP -eq 1) {
-    Write-Host "HIP enabled, including in build"
-
-    $extraCmakeArgs += "-DGGML_HIP=ON"
-
-    if ($env:DAMDGPU_TARGETS) {
-        $extraCmakeArgs += @(
-            "-DDAMDGPU_TARGETS=$env:DAMDGPU_TARGETS"
-        )
-    }
-}
-
 cmake . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release $extraCmakeArgs
 cmake --build build --config Release --target deno_cpp_binding -j $jobs
 Copy-Item build/*.dll ../lib

--- a/bindings/bindings.ps1
+++ b/bindings/bindings.ps1
@@ -26,6 +26,12 @@ if ($env:GGML_CUDA -eq 1) {
     }
 }
 
+if ($env:DGGML_VULKAN -eq 1) {
+    Write-Host "Vulkan enabled, including in build"
+
+    $extraCmakeArgs += "-DGGML_VULKAN=ON"
+}
+
 cmake . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release $extraCmakeArgs
 cmake --build build --config Release --target deno_cpp_binding -j $jobs
 Copy-Item build/*.dll ../lib

--- a/bindings/bindings.ps1
+++ b/bindings/bindings.ps1
@@ -29,7 +29,7 @@ if ($env:GGML_CUDA -eq 1) {
 if ($env:GGML_VULKAN -eq 1) {
     Write-Host "Vulkan enabled, including in build"
 
-    $extraCmakeArgs += "-GGML_VULKAN=ON"
+    $extraCmakeArgs += "-DGGML_VULKAN=ON"
 }
 
 cmake . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release $extraCmakeArgs

--- a/bindings/bindings.sh
+++ b/bindings/bindings.sh
@@ -25,6 +25,22 @@ if [ "$GGML_CUDA" = "1" ]; then
     fi
 fi
 
+if [ "$DGGML_VULKAN" = "1" ]; then
+    EXTRA_CMAKE_ARGS+=("-DGGML_VULKAN=ON")
+    echo "Vulkan enabled, including in build"
+fi
+
+if [ "$DGGML_HIP" = "1" ]; then
+    EXTRA_CMAKE_ARGS+=("-DGGML_HIP=ON")
+    echo "HIP enabled, including in build"
+
+    if [ -n "$DAMDGPU_TARGETS" ]; then
+        EXTRA_CMAKE_ARGS+=(
+            "-DDAMDGPU_TARGETS=$DAMDGPU_TARGETS"
+        )
+    fi
+fi
+
 # Join array elements with spaces
 CMAKE_ARGS="${EXTRA_CMAKE_ARGS[*]}"
 

--- a/bindings/bindings.sh
+++ b/bindings/bindings.sh
@@ -25,18 +25,18 @@ if [ "$GGML_CUDA" = "1" ]; then
     fi
 fi
 
-if [ "$DGGML_VULKAN" = "1" ]; then
-    EXTRA_CMAKE_ARGS+=("-DGGML_VULKAN=ON")
+if [ "$GGML_VULKAN" = "1" ]; then
+    EXTRA_CMAKE_ARGS+=("-GGML_VULKAN=ON")
     echo "Vulkan enabled, including in build"
 fi
 
-if [ "$DGGML_HIP" = "1" ]; then
-    EXTRA_CMAKE_ARGS+=("-DGGML_HIP=ON")
+if [ "$GGML_HIP" = "1" ]; then
+    EXTRA_CMAKE_ARGS+=("-GGML_HIP=ON")
     echo "HIP enabled, including in build"
 
-    if [ -n "$DAMDGPU_TARGETS" ]; then
+    if [ -n "$AMDGPU_TARGETS" ]; then
         EXTRA_CMAKE_ARGS+=(
-            "-DDAMDGPU_TARGETS=$DAMDGPU_TARGETS"
+            "-DAMDGPU_TARGETS=$AMDGPU_TARGETS"
         )
     fi
 fi

--- a/bindings/bindings.sh
+++ b/bindings/bindings.sh
@@ -36,7 +36,7 @@ if [ "$GGML_HIP" = "1" ]; then
 
     if [ -n "$AMDGPU_TARGETS" ]; then
         EXTRA_CMAKE_ARGS+=(
-            "-DDAMDGPU_TARGETS=$AMDGPU_TARGETS"
+            "-DAMDGPU_TARGETS=$AMDGPU_TARGETS"
         )
     fi
 fi

--- a/bindings/bindings.sh
+++ b/bindings/bindings.sh
@@ -26,17 +26,17 @@ if [ "$GGML_CUDA" = "1" ]; then
 fi
 
 if [ "$GGML_VULKAN" = "1" ]; then
-    EXTRA_CMAKE_ARGS+=("-GGML_VULKAN=ON")
+    EXTRA_CMAKE_ARGS+=("-DGGML_VULKAN=ON")
     echo "Vulkan enabled, including in build"
 fi
 
 if [ "$GGML_HIP" = "1" ]; then
-    EXTRA_CMAKE_ARGS+=("-GGML_HIP=ON")
+    EXTRA_CMAKE_ARGS+=("-DGGML_HIP=ON")
     echo "HIP enabled, including in build"
 
     if [ -n "$AMDGPU_TARGETS" ]; then
         EXTRA_CMAKE_ARGS+=(
-            "-DAMDGPU_TARGETS=$AMDGPU_TARGETS"
+            "-DDAMDGPU_TARGETS=$AMDGPU_TARGETS"
         )
     fi
 fi


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
https://github.com/theroyallab/YALS/issues/7

**Why should this feature be added?**
Allow AMD owners to use their GPU's

**Examples**
Increased t/s for AMD users. 

**Additional context**
Some quants seem to have issues as mentioned [here](https://github.com/ggml-org/llama.cpp/issues/10710?utm_source=weekly-project-news&utm_medium=email&utm_campaign=weekly-github-report-for-llamacpp-2024-12-16-8059?utm_campaign=weekly-github-report-for-llamacpp-2024-12-16-8059&utm_medium=email&utm_source=weekly-project-news) if you get gibberish outputs that would be why. (I can confirm issues with IQ3 quants)
Building requires some setup for windows as described [here](https://github.com/ggml-org/llama.cpp/blob/be7c3034108473beda214fd1d7c98fd6a7a3bdf5/docs/build.md#vulkan)

Was not able to get HIP working on windows due to some path issues, but theoretically it should work. 

DAMDGPU_TARGETS should equal something like "gfx1030"
