### PR TITLE
Logical simplification to new backend, bugfix for obscure edge case. Hugely improved cancellation.

### DIFF
--- a/bindings/job.ts
+++ b/bindings/job.ts
@@ -45,6 +45,7 @@ export class Job {
         void,
         unknown
     > {
+        this.buffer.reset();
         while (!this.isComplete) {
             const data = await this.readNext();
             if (data === null) {

--- a/bindings/server/processor.hpp
+++ b/bindings/server/processor.hpp
@@ -312,22 +312,24 @@ class Processor {
         int32_t decode_result = -1;
         while (true) {
             decode_result = llama_decode(ctx, batch);
+
+            //Decode aborted, this is not a failure, we can redo the decode.
             if (decode_result == 2) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(5));
                 continue;
             }
-            break;
-        }
-        
-        if (decode_result != 0) {
-            //Terminal error, the full batch decode entirely failed. We need to end everything this is not recoverable.
-            for (auto& slot : slots) {
-                if (slot.i_batch >= 0 && slot.i_batch < batch.n_tokens) {
-                    readback_finish(slot.readback_buffer, make_json_status_string(ctx, "BatchDecode", ""));
-                    slot.end(++current_job_index, ctx);
+
+            //TODO:: @Z We can potentially avoid a hard abort depending on the status code. Investigate if possibel.
+            if (decode_result != 0) {
+                for (auto& slot : slots) {
+                    if (slot.i_batch >= 0 && slot.i_batch < batch.n_tokens) {
+                        readback_finish(slot.readback_buffer, make_json_status_string(ctx, "BatchDecode", ""));
+                        slot.end(++current_job_index, ctx);
+                    }
                 }
+                return;
             }
-            return;
+            break;
         }
 
         for (auto& slot : slots) {

--- a/bindings/server/processor.hpp
+++ b/bindings/server/processor.hpp
@@ -165,9 +165,6 @@ class Processor {
         best_slot->inference_args = inference_args;
         best_slot->readback_buffer = readback_buffer;
 
-        readback_reset(best_slot->readback_buffer);
-        best_slot->generated_text.clear();
-
         best_slot->sequence_stream->bind_sequences(inference_args.stopping_strings, inference_args.rewind_strings);
         best_slot->rewind_snapshot = Slot::SlotSnapshot::snapshot_slot(*best_slot, ctx, false);
 

--- a/bindings/server/processor.hpp
+++ b/bindings/server/processor.hpp
@@ -309,11 +309,17 @@ class Processor {
             return;
         }
 
-        const auto decode_result = llama_decode(ctx, batch);
-        if (decode_result != 0) {
+        int32_t decode_result = -1;
+        while (true) {
+            decode_result = llama_decode(ctx, batch);
             if (decode_result == 2) {
-                return;
+                std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                continue;
             }
+            break;
+        }
+        
+        if (decode_result != 0) {
             //Terminal error, the full batch decode entirely failed. We need to end everything this is not recoverable.
             for (auto& slot : slots) {
                 if (slot.i_batch >= 0 && slot.i_batch < batch.n_tokens) {

--- a/bindings/server/slot.hpp
+++ b/bindings/server/slot.hpp
@@ -105,33 +105,7 @@ struct Slot {
         generated_text.clear();
         detokenizer->reset();
     }
-
-    void print_dbg_info(llama_context* ctx) const {
-        std::cout << "=== Slot Debug Info ===\n";
-        std::cout << "KV cache size: " << llama_kv_self_seq_pos_max(ctx, slot_id) << std:: endl;
-        std::cout << "job_index: " << job_index << "\n";
-        std::cout << "request_id: " << request_id << "\n";
-        std::cout << "slot_id: " << slot_id << "\n";
-
-        std::cout << "state: ";
-        switch (state) {
-            case State::IDLE:      std::cout << "IDLE"; break;
-            case State::PROMPT:    std::cout << "PROMPT"; break;
-            case State::GENERATING: std::cout << "GENERATING"; break;
-            default:               std::cout << static_cast<int>(state); break;
-        }
-        std::cout << "\n";
-
-        std::cout << "prompt_tokens.size(): " << prompt_tokens.size() << "\n";
-        std::cout << "prompt_tokens_processed: " << prompt_tokens_processed << "\n";
-        std::cout << "tokens_generated: " << tokens_generated << "\n";
-        std::cout << "n_past: " << n_past << "\n";
-        std::cout << "i_batch: " << i_batch << "\n";
-        std::cout << "last_token: " << last_token << "\n";
-        std::cout << "generated_text: \"" << generated_text << "\"\n";
-        std::cout << "======================\n";
-    }
-
+    
     void end(const int new_id, llama_context* ctx) {
         clear();
         job_index = new_id;

--- a/bindings/server/slot.hpp
+++ b/bindings/server/slot.hpp
@@ -32,7 +32,6 @@ struct Slot {
         llama_token last_token{};
         std::string previous_seq_stream_buffer;
         int32_t previous_kv_pos{};
-        bool last_token_prompt{};
 
         static SlotSnapshot snapshot_slot(const Slot& slot, llama_context* ctx, const bool during_prompt) {
             SlotSnapshot snapshot;
@@ -42,8 +41,6 @@ struct Slot {
             snapshot.i_batch = slot.i_batch;
             snapshot.last_token = slot.last_token;
             snapshot.previous_seq_stream_buffer = slot.sequence_stream->sequence_buffer;
-
-            snapshot.last_token_prompt = during_prompt;
 
             // During the prompt because we do not call decode, we need a special case to update the kv pos for prompt
             snapshot.previous_kv_pos = during_prompt ? slot.n_past : llama_kv_self_seq_pos_max(ctx, slot.slot_id);
@@ -72,8 +69,6 @@ struct Slot {
 
     int n_past = 0;
     int i_batch = -1;
-
-    bool test_safeguard = false;
 
     llama_token last_token = 0;
     std::string generated_text;


### PR DESCRIPTION
Removed a ton of edge cases by refactoring logical flow in the processor.

Bugfix for KV off-by-one in a very specific scenario involving rewinding the very first token of a prompt.

Fixes for cancellation and overall simplified, it no longer will contain residuals of old generations in cases where cancellation overlapped with a new generation request.