### PR TITLE
Actions: Pin Deno version to v2.2.10 for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.2.10
       - name: Setup Ninja
         uses: seanmiddleditch/gha-setup-ninja@master
       - name: Setup Rust
@@ -184,7 +184,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.2.10
       - name: Setup Ninja
         uses: seanmiddleditch/gha-setup-ninja@master
       - name: Setup Rust


### PR DESCRIPTION
**Warning**
~~Make all Pull Requests to the dev branch. Main is reserved for stability and building actions.~~  
This is relevant to the CI, I hope it's okay to PR to `main`?

**Is your pull request related to a problem? Please describe.**
Refer to https://github.com/denoland/deno/issues/28982, `deno compile`d executables are broken on Windows on newer 2.2.11, so lets just pin all of them

**Why should this feature be added?**
Fixes Windows CI builds. This is probably better to avoid any random breaking changes with unpinned versions anyways

**Examples**
N/A

**Additional context**
N/A
