### PR TITLE
Prevent empty JSON schema from constraining output

### DIFF
--- a/bindings/grammar.ts
+++ b/bindings/grammar.ts
@@ -30,6 +30,11 @@ export class YALSGrammar {
             return;
         }
 
+        // Skip empty schemas to match behavior with TabbyAPI
+        if (Object.keys(schema).length === 0) {
+            return;
+        }
+
         const grammarArray = ["start: json_object"];
         const schemaString = JSON.stringify(
             schema,


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

When an empty JSON schema (json_schema: {}) is included in the API request, the output generation is constrained. This behavior conflicts with how TabbyAPI seems to be working and causes issues with SillyTavern integration (which sends json_schema {} by default).

**Why should this feature be added?**

- It matches the behavior with TabbyAPI
- Fixes issues with client integrations that automatically include empty JSON schemas (including SillyTavern)

**Examples**

Behavior without the fix:

```bash
# Without JSON schema produces expected response:
curl -X POST http://127.0.0.1:5000/v1/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer API_TOKEN" \
  -d '{
    "temperature": 1,
    "min_p": 0.01,
    "prompt": "<|header_start|>user<|header_end|>\n\nTell me a fun fact about cats<|eot|><|header_start|>assistant<|header_end|>"
  }'

{"choices":[{"index":0,"finish_reason":"stop","text":"\nHere's a fun fact about cats:\n\n**A group of cats is called a \"clowder\"!** \n\nIsn't that a delightful word? It sounds like something straight out of a fairy tale! They also have other collective nouns, like a \"glaring\" for cats fighting, or a \"pounce\" when they're hunting!\n<|eot"}],...}

# With empty JSON schema:
curl -X POST http://127.0.0.1:5000/v1/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer API_TOKEN" \
  -d '{
    "temperature": 1,
    "min_p": 0.01,
    "json_schema": {},
    "prompt": "<|header_start|>user<|header_end|>\n\nTell me a fun fact about cats<|eot|><|header_start|>assistant<|header_end|>"
  }'

{"choices":[{"index":0,"finish_reason":"stop","text":"0.05"}],...}
```

Empty JSON Schema {} probably means that "any JSON is valid" in the JSON Schema specs, but this change matches how TabbyAPI works. 

The alternative to this fix would be to fix the client integrations to not send json_schema {}. 